### PR TITLE
Fix: Update multi-llm-agent tooling call and bump version to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphteon/juriko-cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "JURIKO - An open-source AI agent that brings the power of AI directly into your terminal.",
   "main": "dist/index.js",
   "bin": {

--- a/test/condense-fix-test.js
+++ b/test/condense-fix-test.js
@@ -1,0 +1,50 @@
+const { MultiLLMAgent } = require('../dist/agent/multi-llm-agent');
+const { LLMClient } = require('../dist/llm/client');
+
+async function testCondenseWithCurrentModel() {
+  console.log('🧪 Testing condense feature with current model...');
+  
+  // Create a mock LLM config for Anthropic (current model)
+  const llmConfig = {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-20250514',
+    apiKey: process.env.ANTHROPIC_API_KEY || 'test-key',
+    baseURL: undefined
+  };
+  
+  try {
+    // Create LLM client and agent
+    const llmClient = new LLMClient(llmConfig);
+    const agent = new MultiLLMAgent(llmClient, llmConfig);
+    
+    // Test that the agent correctly derives the LLM config
+    const derivedConfig = agent.deriveLLMConfigFromClient();
+    
+    console.log('✅ Current model:', llmClient.getCurrentModel());
+    console.log('✅ Derived config provider:', derivedConfig.provider);
+    console.log('✅ Derived config model:', derivedConfig.model);
+    
+    // Verify that the config matches Anthropic
+    if (derivedConfig.provider === 'anthropic' && derivedConfig.model.includes('claude')) {
+      console.log('✅ SUCCESS: Condense feature will use Anthropic instead of OpenAI');
+      return true;
+    } else {
+      console.log('❌ FAILED: Config derivation not working correctly');
+      return false;
+    }
+    
+  } catch (error) {
+    console.error('❌ Test failed:', error.message);
+    return false;
+  }
+}
+
+// Run the test
+testCondenseWithCurrentModel()
+  .then(success => {
+    process.exit(success ? 0 : 1);
+  })
+  .catch(error => {
+    console.error('❌ Test error:', error);
+    process.exit(1);
+  });


### PR DESCRIPTION
This PR includes:

- Fixed multi-llm-agent tooling call implementation
- Added condense test for validation
- Bumped version from 0.1.3 to 0.1.4
- Published to npm as @graphteon/juriko-cli@0.1.4

